### PR TITLE
Add a simple package for registering/servicing HTTP01 challenge responses.

### DIFF
--- a/pkg/challenger/challenger.go
+++ b/pkg/challenger/challenger.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package challenger
+
+import (
+	context "context"
+	"net/http"
+	"sync"
+)
+
+// Interface defines the interface for handling register, unregistering,
+// and serving challenge responses.
+type Interface interface {
+	http.Handler
+
+	RegisterChallenge(path, response string)
+	UnregisterChallenge(path string)
+}
+
+// New creates a new challenger instance, which can be exposed on an http.Server.
+func New(ctx context.Context) (Interface, error) {
+	return &challenger{}, nil
+}
+
+type challenger struct {
+	sync.RWMutex
+
+	paths map[string]string
+}
+
+var _ Interface = (*challenger)(nil)
+
+func (c *challenger) RegisterChallenge(path, response string) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.paths == nil {
+		c.paths = make(map[string]string, 1)
+	}
+	c.paths[path] = response
+}
+
+func (c *challenger) UnregisterChallenge(path string) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.paths != nil {
+		delete(c.paths, path)
+	}
+}
+
+func (c *challenger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.paths == nil {
+		http.Error(w, "Unknown path", http.StatusNotFound)
+		return
+	}
+	resp, ok := c.paths[r.URL.Path]
+	if !ok {
+		http.Error(w, "Unknown path", http.StatusNotFound)
+		return
+	}
+	w.Write([]byte(resp))
+}

--- a/pkg/challenger/challenger_test.go
+++ b/pkg/challenger/challenger_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package challenger
+
+import (
+	context "context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBasicLifecycle(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths map[string]string
+	}{{
+		name: "single",
+		paths: map[string]string{
+			"/foo/bar": "baz",
+		},
+	}, {
+		name: "multiple",
+		paths: map[string]string{
+			"/foo/bar":                      "baz",
+			"/.well-known/acme/dsaflkjhsdf": "ugh",
+			"/wtf":                          "is this",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := New(context.Background())
+			if err != nil {
+				t.Fatalf("New() = %v", err)
+			}
+
+			// Check before registering
+			for path := range test.paths {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				rec := httptest.NewRecorder()
+				c.ServeHTTP(rec, req)
+
+				if got, want := rec.Result().StatusCode, http.StatusNotFound; got != want {
+					t.Errorf("SeverHTTP(before register) = %d, wanted %d", got, want)
+				}
+			}
+
+			// Check after registering
+			for path, payload := range test.paths {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				rec := httptest.NewRecorder()
+
+				c.RegisterChallenge(path, payload)
+				c.ServeHTTP(rec, req)
+				if got, want := rec.Result().StatusCode, http.StatusOK; got != want {
+					t.Errorf("SeverHTTP(after register) = %d, wanted %d", got, want)
+				}
+
+				body, err := ioutil.ReadAll(rec.Result().Body)
+				if err != nil {
+					t.Errorf("ReadAll() = %v", err)
+				} else if got, want := string(body), payload; got != want {
+					t.Errorf("ReadAll() = %s, wanted %s", got, want)
+				}
+			}
+
+			// Check after unregistering
+			for path := range test.paths {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				rec := httptest.NewRecorder()
+
+				c.UnregisterChallenge(path)
+				c.ServeHTTP(rec, req)
+
+				if got, want := rec.Result().StatusCode, http.StatusNotFound; got != want {
+					t.Errorf("SeverHTTP(after unregister) = %d, wanted %d", got, want)
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
The `challenger` package provides a simple interface for implementations
to register new HTTP01 challenge responses for the `http.Handler` to
serve.

WIP until https://github.com/knative/net-http01/pull/1 merges.